### PR TITLE
Support Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,5 @@ internetarchive:
 	rm $(src)/$(WHOAMI)-$(YMD).tar.bz2
 
 spec:
-	python2 ./bin/compile.py > data/sources-spec-`date "+%Y%m%d"`.json
+	python ./bin/compile.py > data/sources-spec-`date "+%Y%m%d"`.json
 	cp data/sources-spec-`date "+%Y%m%d"`.json data/sources-spec-latest.json

--- a/bin/compile.py
+++ b/bin/compile.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
             try:
                 fh = open(path, 'r')
                 data = json.load(fh)
-            except Exception, e:
+            except Exception as e:
                 logging.error("failed to parse %s, because %s" % (path, e))
                 sys.exit()
 
@@ -57,5 +57,5 @@ if __name__ == '__main__':
 
             spec[data['id']] = data
 
-    print json.dumps(spec)
+    print (json.dumps(spec))
     sys.exit(0)

--- a/bin/docs.py
+++ b/bin/docs.py
@@ -4,9 +4,6 @@
 from __future__ import unicode_literals
 
 import sys
-reload(sys)
-sys.setdefaultencoding('utf8')
-
 import os
 import logging
 import datetime
@@ -41,7 +38,7 @@ if __name__ == '__main__':
         lookup[details['name']] = id
 
     names = lookup.keys()
-    names.sort()
+    names = sorted(names)
 
     #now write the license out
     _license = io.open(license, "w")


### PR DESCRIPTION
Fixes https://github.com/whosonfirst/whosonfirst-sources/issues/167.

This PR updates the `compile.py`, `docs.py`, and `Makefile` to be Python 3 compatible. I've verified the changes work, and docs write out correctly.

Running the `make all` command...
```
>>>$ make all
python ./bin/compile.py > data/sources-spec-`date "+%Y%m%d"`.json
cp data/sources-spec-`date "+%Y%m%d"`.json data/sources-spec-latest.json
python ./bin/docs.py
```

Results in the expected...
```
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   LICENSE.md
	modified:   data/sources-spec-latest.json
	modified:   sources/README.md

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	data/sources-spec-20200427.json
```