### PR TITLE
Docs update and Python 2.7 vs. 3.x Makefile wrangling fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ archive: all
 	tar --exclude='.git*' --exclude='Makefile*' -cvjf $(dest)/$(WHOAMI)-$(YMD).tar.bz2 ./bin ./data ./sources ./LICENSE.md ./CONTRIBUTING.md ./README.md
 
 docs:
-	python ./bin/docs.py
+	${PYTHON} ./bin/docs.py
 
 # https://internetarchive.readthedocs.org/en/latest/cli.html#upload
 # https://internetarchive.readthedocs.org/en/latest/quickstart.html#configuring
@@ -25,5 +25,5 @@ internetarchive:
 	rm $(src)/$(WHOAMI)-$(YMD).tar.bz2
 
 spec:
-	python ./bin/compile.py > data/sources-spec-`date "+%Y%m%d"`.json
+	${PYTHON} ./bin/compile.py > data/sources-spec-`date "+%Y%m%d"`.json
 	cp data/sources-spec-`date "+%Y%m%d"`.json data/sources-spec-latest.json

--- a/README.md
+++ b/README.md
@@ -4,13 +4,19 @@ Where things come from in Who's On First.
 
 Click [here](sources/README.md) to see a full list of Who's On First sources.
 
-### Adding a new source
+## Installation
+
+```
+sudo pip install -r requirements.txt .
+```
+
+## Adding a new source
 
 1. Create a new source .json file using the [template file](source_template.json).
 2. Fill out all required properties and optional properties, if available.
 3. Run the [Makefile](Makefile) using the `make all` command.
 
-### Source Properties
+## Source Properties
 
 While a source .json file in the `whosonfirst-sources` repository does not require all properties listed below, the more information we are able to gather about a source, the better. When adding a new source, please provide as much current, available information about that specific source as possible.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ sudo pip install -r requirements.txt .
 2. Fill out all required properties and optional properties, if available.
 3. Run the [Makefile](Makefile) using the `make all` command.
 
+### Python 3 Health Warning
+
+The scripts in this repo's `./bin` directory require and _assume_ Python 3.
+
+If your default Python is still 2.7.x (as many people's still are), this will cause these scripts to complain in a pained manner. Setting the `PYTHON` environment variable as part of running the `Makefile` will make the scripts happy and run, something like this ...
+
+```
+PYTHON=`which python3` make all
+```
+
+If your default Python _is_ 3.x then you can safely ignore this.
+
 ## Source Properties
 
 While a source .json file in the `whosonfirst-sources` repository does not require all properties listed below, the more information we are able to gather about a source, the better. When adding a new source, please provide as much current, available information about that specific source as possible.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+internetarchive


### PR DESCRIPTION
As discussed in #174, this PR does ...

* Add dependencies installation of `internetarchive` to keep the `Makefile`'s `ia` and `internetarchive` targets happy
* Add to `README.md` that installing this dependency is a good idea
* Allow people with 2.7.x as their default Python to set Python 3 in the environment when running `make all`
* Add to `README.md` words to this effect